### PR TITLE
Making it work

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,4 @@
 platform = teensy
 board = teensylc
 framework = arduino
-lib_deps = 
-	thomasfredericks/Bounce2@^2.71
 build_flags = -D USB_MIDI -D TEENSY_OPT_FASTEST

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,7 @@ int8_t getActiveKeyGroup() {
   int8_t last_active_key_group = -1;
   for (uint8_t i = 0; i < KEY_GROUP_NUM; i++) {
     // Update status
-    if (digitalReadFast(group_pins[i])==LOW){
+    if (digitalReadFast(group_pins[i]) == LOW){
       last_active_key_group = (int8_t) i;
       active_groups++;
     }
@@ -73,7 +73,7 @@ int8_t getActiveKeyGroup() {
 // Set the next self drive pin
 FASTRUN void nextSelfDrivePin() {
   // Set the current pin to high
-  digitalWriteFast(self_drive_pins[current_self_drive_pin!=0?current_self_drive_pin-1:KEY_GROUP_NUM-1], LOW);
+  digitalWriteFast(self_drive_pins[current_self_drive_pin != 0 ? current_self_drive_pin - 1 : KEY_GROUP_NUM - 1], LOW);
   digitalWriteFast(self_drive_pins[current_self_drive_pin], HIGH);
   // Set the next pin
   current_self_drive_pin = (current_self_drive_pin + 1) % KEY_GROUP_NUM;
@@ -118,14 +118,16 @@ void loop() {
           // Send MIDI message
           usbMIDI.sendNoteOn(mapToMidi(active_key_group, i), 127, 1);
         }
+
         // Set the entry in the array
-          keys_pressed[active_key_group * 6 + i] += keys_pressed[active_key_group * 6 + i] < 0xFF? 1:0;
+        keys_pressed[active_key_group * 6 + i] += keys_pressed[active_key_group * 6 + i] < 0xFF ? 1 : 0;
       } else {
         // Check if the key is not already released
         if (keys_pressed[active_key_group * 6 + i] < DEBOUNCE_TIMES) {
           // Send MIDI message
           usbMIDI.sendNoteOff(mapToMidi(active_key_group, i), 0, 1);
         }
+
         // Set the entry in the array
         keys_pressed[active_key_group * 6 + i] = 0;
       }
@@ -133,8 +135,7 @@ void loop() {
   }
 
   // MIDI Controllers should discard incoming MIDI messages.
-  while (usbMIDI.read()) {
-  }
+  while (usbMIDI.read()) {}
 
   // switch to next key group, if self powered
   if (digitalReadFast(POWER_SUPPLY_CHECK_PIN) == LOW) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,15 +4,15 @@
 #define MIDI_NAME {'P', 'i', 'n', 'g', 'b', 'o', 'a', 'r', 'd'}
 #define MIDI_NAME_LEN 9
 
-#define CHECK_PINS 9
+#define KEY_GROUP_NUM 9
 #define KEY_PINS 6
+#define NUMBER_OF_KEYS 49
 #define BOUNCE_TIME 5
 #define POWER_SUPPLY_CHECK_PIN 13
 
-#define NUMBER_OF_KEYS 49
 #define SELF_DRIVE_INTERVAL 100
 
-Bounce check_pins[CHECK_PINS] {
+Bounce group_pins[KEY_GROUP_NUM] {
   {14, BOUNCE_TIME}, // not KEYS1..6
   {15, BOUNCE_TIME}, // not KEYS7..12
   {16, BOUNCE_TIME}, // not KEYS13..18
@@ -25,20 +25,20 @@ Bounce check_pins[CHECK_PINS] {
 };
 
 // not KEY0%6..not KEY5%6
-const unsigned char key_pins[KEY_PINS] {2, 3, 4, 5, 6, 7};
+const uint8_t key_pins[KEY_PINS] {2, 3, 4, 5, 6, 7};
 // Array of pressed keys (initially all 0)
 bool keys_pressed[NUMBER_OF_KEYS];
 // K1, K2, K3, K4, K5, K12, K13, K14, K15
-const unsigned char self_drive_pins[CHECK_PINS] {8, 9, 10, 11, 12, 26, 23, 24, 25};
-volatile unsigned char curr_self_drive_pin = 0;
+const uint8_t self_drive_pins[KEY_GROUP_NUM] {8, 9, 10, 11, 12, 26, 23, 24, 25};
+volatile uint8_t current_self_drive_pin = 0;
 IntervalTimer self_drive_timer = IntervalTimer();
 
 // Map the current array and pressed key to a MIDI note
-unsigned char mapToMidi(char curr_arr, char key) {
-  unsigned char offset = (curr_arr >> 1) * 12;
+uint8_t mapToMidi(uint8_t active_key_group, uint8_t key) {
+  uint8_t offset = (active_key_group >> 1) * 12;
   // TODO: maybe we have to switch the notes and array offsets
   // Uneven offset are the upper octave, even the lower
-  if (curr_arr & 1) {
+  if (active_key_group & 1) {
     switch (key) {
       case 0: return offset + 42; // F#2 + offset
       case 1: return offset + 43; // G2 + offset
@@ -63,18 +63,18 @@ unsigned char mapToMidi(char curr_arr, char key) {
 }
 
 // Check if any of the array pins fell since last time
-char findCurrentArrPin() {
-  for (unsigned char i = 0; i < CHECK_PINS; i++) {
+int8_t getActiveKeyGroup() {
+  for (uint8_t i = 0; i < KEY_GROUP_NUM; i++) {
     // Update status
-    check_pins[i].update();
+    group_pins[i].update();
     // Check if the pin fell or is low
     // ! inverted
-    if (check_pins[i].fell()) return i;
+    if (group_pins[i].fell()) return i;
   }
 
   // If none fell we should have enough time to see which one is low
-  for (unsigned char i = 0; i < CHECK_PINS; i++) {
-    if (check_pins[i].read() == LOW) return i;
+  for (uint8_t i = 0; i < KEY_GROUP_NUM; i++) {
+    if (group_pins[i].read() == LOW) return i;
   }
 
   // Default return
@@ -84,17 +84,17 @@ char findCurrentArrPin() {
 // Set the next self drive pin
 FASTRUN void nextSelfDrivePin() {
   // Set the current pin to high
-  digitalWriteFast(self_drive_pins[curr_self_drive_pin], HIGH);
+  digitalWriteFast(self_drive_pins[current_self_drive_pin], HIGH);
   // Set the next pin
-  curr_self_drive_pin = (curr_self_drive_pin + 1) % CHECK_PINS;
+  current_self_drive_pin = (current_self_drive_pin + 1) % KEY_GROUP_NUM;
 }
 
 // Interrupt for power supply check
 FASTRUN void powerStateChanged() {
-  unsigned char state = digitalReadFast(POWER_SUPPLY_CHECK_PIN);
+  uint8_t state = digitalReadFast(POWER_SUPPLY_CHECK_PIN);
   // ! inverted
   if (state == LOW) {
-    curr_self_drive_pin = 0;
+    current_self_drive_pin = 0;
     self_drive_timer.begin(nextSelfDrivePin, SELF_DRIVE_INTERVAL);
   } else {
     self_drive_timer.end();
@@ -104,11 +104,11 @@ FASTRUN void powerStateChanged() {
 // Initial start function
 void setup() {
   // Set all in- and outputs
-  for (unsigned char i = 0; i < CHECK_PINS; i++) {
-    pinMode(check_pins[i].getPin(), INPUT);
+  for (uint8_t i = 0; i < KEY_GROUP_NUM; i++) {
+    pinMode(group_pins[i].getPin(), INPUT);
     pinMode(self_drive_pins[i], INPUT);
   }
-  for (unsigned char i = 0; i < KEY_PINS; i++) {
+  for (uint8_t i = 0; i < KEY_PINS; i++) {
     pinMode(key_pins[i], INPUT);
   }
   pinMode(POWER_SUPPLY_CHECK_PIN, INPUT);
@@ -121,32 +121,32 @@ void setup() {
 // Main loop
 void loop() {
   // Find active arr pin
-  char curr_arr = findCurrentArrPin();  
+  int8_t active_key_group = getActiveKeyGroup();  
 
   // If none is active, we do nothing, else we check the keys
-  if (curr_arr >= 0) {
+  if (active_key_group >= 0) {
     // Get all the key values ans send the MIDI message if needed
-    unsigned char value;
+    uint8_t value;
     
-    for (unsigned char i = 0; i < KEY_PINS; i++) {
+    for (uint8_t i = 0; i < KEY_PINS; i++) {
       value = digitalReadFast(key_pins[i]);
       // If the key is pressed, we send a MIDI message and set the entry in the array
       // ! inverted
       if (value == LOW) { 
         // Check if the key is not already pressed
-        if (keys_pressed[curr_arr * 6 + i] == 0) {
+        if (keys_pressed[active_key_group * 6 + i] == 0) {
           // Send MIDI message
-          usbMIDI.sendNoteOn(mapToMidi(curr_arr, i), 127, 1);
+          usbMIDI.sendNoteOn(mapToMidi(active_key_group, i), 127, 1);
           // Set the entry in the array
-          keys_pressed[curr_arr * 6 + i] = 1;
+          keys_pressed[active_key_group * 6 + i] = 1;
         }
       } else {
         // Check if the key is not already released
-        if (keys_pressed[curr_arr * 6 + i] == 1) {
+        if (keys_pressed[active_key_group * 6 + i] == 1) {
           // Send MIDI message
-          usbMIDI.sendNoteOff(mapToMidi(curr_arr, i), 0, 1);
+          usbMIDI.sendNoteOff(mapToMidi(active_key_group, i), 0, 1);
           // Set the entry in the array
-          keys_pressed[curr_arr * 6 + i] = 0;
+          keys_pressed[active_key_group * 6 + i] = 0;
         }
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,15 +27,15 @@ IntervalTimer self_drive_timer = IntervalTimer();
 // Map the current array and pressed key to a MIDI note
 uint8_t mapToMidi(uint8_t active_key_group, uint8_t key) {
   uint8_t offset = (active_key_group >> 1) * 12;
-  // TODO: maybe we have to switch the notes and array offsets
+  // case 3 and case 4 are swapped on purpose to reflect circuitry
   // Uneven offset are the upper octave, even the lower
   if (active_key_group & 1) {
     switch (key) {
       case 0: return offset + 42; // F#2 + offset
       case 1: return offset + 43; // G2 + offset
       case 2: return offset + 44; // G#2 + offset
-      case 3: return offset + 45; // A2 + offset
-      case 4: return offset + 46; // A#2 + offset
+      case 4: return offset + 45; // A2 + offset
+      case 3: return offset + 46; // A#2 + offset
       case 5: return offset + 47; // B2 + offset
     }
   } else {
@@ -43,8 +43,8 @@ uint8_t mapToMidi(uint8_t active_key_group, uint8_t key) {
       case 0: return offset + 36; // C2 + offset
       case 1: return offset + 37; // C#2 + offset
       case 2: return offset + 38; // D2 + offset
-      case 3: return offset + 39; // D#2 + offset
-      case 4: return offset + 40; // E2 + offset
+      case 4: return offset + 39; // D#2 + offset
+      case 3: return offset + 40; // E2 + offset
       case 5: return offset + 41; // F2 + offset
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,7 @@ void setup() {
   // Set all in- and outputs
   for (uint8_t i = 0; i < KEY_GROUP_NUM; i++) {
     pinMode(group_pins[i], INPUT);
-    pinMode(self_drive_pins[i], INPUT);
+    pinMode(self_drive_pins[i], OUTPUT);
   }
   for (uint8_t i = 0; i < KEY_PINS; i++) {
     pinMode(key_pins[i], INPUT);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,6 +121,12 @@ void loop() {
     uint8_t value;
     
     for (uint8_t i = 0; i < KEY_PINS; i++) {
+      // due to the circuitry, there is one phantom note above
+      // the highest key constantly 'playing'
+      // but we don't need to scan that far anyway 
+      if (active_key_group == KEY_GROUP_NUM-1 && i>0){
+        break;
+      }
       value = digitalReadFast(key_pins[i]);
       // If the key is pressed, we send a MIDI message and set the entry in the array
       // ! inverted


### PR DESCRIPTION
I've fixed the issue of "It doesn't work at all".
Please see the commit messages for individual steps.

These are my notes while working on it:\
Bounce seems to use milliseconds internally. While for human button presses that might be ok,
these here are generated in fast succession by another IC and debouncing them will not yield good results.
One should check the pulse duration, I bet it's at or below a couple of milliseconds.

.read also uses the thereby determined state

We do however need to "debounce" still, as for some reason the Keypins dont become high fast enough when there is a new
keygroup being switched to - leading to ugly arpeggio.

Maybe having the same key being active at least twice suffices? (bool->uint8, increment if under 255, maybe.)
Works well with single keys.

|Especially with multiple keys inside one key group being pressed this turns bad, though.
| So maybe we need some kind of hysteresis here. Waiting until the key has been detected as depressed twice makes for a good "on" switch
|Maybe we need to see if it was "turned off twice" too?

|I tried it with turning off after 255 cycles, just for fun.
|Turns out the weird arpeggio still exists, so there might be something off with what is being sent via midi?
|> scrap all that, user error caused lmms to clip which sounded awful. Works fine!

Some keys wrongly send their neighboring note, though.
Fixed. (case 3&4 needed switching around)

Onto self powered mode!
self_drive_pins were set as INPUT, for some reason, which certainly played nicely with digitalWriteFast!
(while (true); as an interrupt routine?!)

Pinned "state" in powerStateChanged LOW, as we have nothing connected electrically. Unplugged keyboard of course.
Works well with some keys, arpeggio with others. 100µs as a polling interval for the groups is a bit short though.
Increased to 1ms, better but not perfect.

I believe this is caused by the timer going off during polling the pins. Since there seems to be some overlap of group polling intervals
when the Keyboard IC polls, maybe switching them around helps (so that there is _some_ group active all of the time, even if they're 2 occasionaly)
Maybe a bit... Why is this a nonissue when the Keyboard IC does the polling?
Quite a bit, increasing group switching rate again doesn't make the result worse.
The "higher" a note inside the key group, the worse it is, interesting.
B and G are far, far worse than C.

This is probably caused by switching key groups after entering the for loop inside loop()
Turning the Drive_Interval wayy up (10ms) seems to have fixed that.

I'll try syncronizing nextSelfDrivePin (only change outside of inner for loop of loop())
Scrap that, too fragile a solution.

Why do we need to cycle like that anyway? Just switch groups at the end of our loop().
Works perfectly!
Worst case when switching keyboard on is one missed key group on both keyboard and midi.
Nothing goes up in flames, too.